### PR TITLE
FIX: Save actionlint tarball under its upstream filename

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -269,13 +269,15 @@ RUN apt-get update -y \
          *) echo "Unsupported TARGETARCH for actionlint: ${TARGETARCH}" && exit 1 ;; \
        esac \
     && cd /tmp \
-    && curl -fsSL -o actionlint.tar.gz \
-         "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" \
-    && curl -fsSL -o actionlint_checksums.txt \
-         "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
-    && grep "linux_${ACTIONLINT_ARCH}.tar.gz$" actionlint_checksums.txt | sha256sum -c - \
-    && tar -xzf actionlint.tar.gz -C /usr/local/bin actionlint \
-    && rm actionlint.tar.gz actionlint_checksums.txt \
+    && ACTIONLINT_TARBALL="actionlint_${ACTIONLINT_VERSION}_linux_${ACTIONLINT_ARCH}.tar.gz" \
+    && ACTIONLINT_CHECKSUMS="actionlint_${ACTIONLINT_VERSION}_checksums.txt" \
+    && curl -fsSL -O \
+         "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_TARBALL}" \
+    && curl -fsSL -O \
+         "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/${ACTIONLINT_CHECKSUMS}" \
+    && grep " ${ACTIONLINT_TARBALL}$" "${ACTIONLINT_CHECKSUMS}" | sha256sum -c - \
+    && tar -xzf "${ACTIONLINT_TARBALL}" -C /usr/local/bin actionlint \
+    && rm "${ACTIONLINT_TARBALL}" "${ACTIONLINT_CHECKSUMS}" \
     && actionlint -version \
     && shellcheck --version
 


### PR DESCRIPTION
## Summary
Follow-up to #44. The dev-stage build was failing during actionlint install with:

\`\`\`
actionlint_1.7.12_linux_amd64.tar.gz: No such file or directory
sha256sum: WARNING: 1 listed file could not be read
\`\`\`

`actionlint_<v>_checksums.txt` lists each release artifact by its upstream filename, so `sha256sum -c -` reads a line like `<hash>  actionlint_1.7.12_linux_amd64.tar.gz` and looks for a file by that exact name. We were saving the tarball locally as `actionlint.tar.gz`, so the integrity check could never find it.

Fix: use `curl -O` (preserves the URL's filename) and reference the tarball and checksums file via shell variables, so the on-disk names match the checksums file verbatim. No version bump, no behaviour change beyond the broken step now passing.

## Test plan
- [ ] CI matrix builds both `amd64` and `arm64` dev images without errors.
- [ ] Confirm `actionlint -version` and `shellcheck --version` print as the final step of the dev build (already present, but ensure they actually run now that the prior step doesn't bomb out).

🤖 Generated with [Claude Code](https://claude.com/claude-code)